### PR TITLE
Fix build

### DIFF
--- a/build/contrib-requirejs.js
+++ b/build/contrib-requirejs.js
@@ -4,15 +4,22 @@ module.exports = function(grunt) {
     prod: {
       options: {
         baseUrl: '.',
+        paths: {
+          'modules': 'src/modules',
+          'main': 'src/main'
+        },
         include: [
-          'src/modules/web/requirejs/config',
-          'src/modules/mobile/requirejs/config'
+          'modules/web/requirejs/config',
+          'modules/mobile/requirejs/config',
+          'backbone',
+          'modules/web/core/router',
+          'modules/mobile/core/router'
         ],
         mainConfigFile: 'src/requirejs/config.js',
-        insertRequire: ['src/main'],
+        insertRequire: ['main'],
         name: 'bower_components/almond/almond',
         out: 'prod/app.js',
-        optimize: 'uglify2',
+        optimize: 'none',
         generateSourceMaps: true,
         preserveLicenseComments: false,
       },

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ define(function() {
   // requirements:
   var platform = Modernizr.mq('(min-width: 760px)') ? 'web' : 'mobile';
 
-  require(['src/modules/' + platform + '/requirejs/config'], function() {
+  require(['modules/' + platform + '/requirejs/config'], function() {
 
     // load hard dependencies as well as core platform router.
     require(['backbone', 'jquery', 'platform/core/router'], function(Backbone, $, Router) {

--- a/src/modules/mobile/requirejs/config.js
+++ b/src/modules/mobile/requirejs/config.js
@@ -2,11 +2,13 @@ define(function() {
 
   console.log("mobile");
   require.config({
+    map: {
+      "*": {
+        platform: "modules/mobile"
+      }
+    },
 
     paths: {
-
-      platform: "src/modules/mobile",
-
       components: "platform/components",
       layouts: "platform/components/layouts",
       core: "platform/core",

--- a/src/modules/web/requirejs/config.js
+++ b/src/modules/web/requirejs/config.js
@@ -1,10 +1,13 @@
 define(function() {
   require.config({
 
+    map: {
+      "*": {
+        platform: "modules/web"
+      }
+    },
+
     paths: {
-
-      platform: "src/modules/web",
-
       components: "platform/components",
       layouts: "platform/components/layouts",
       core: "platform/core",

--- a/src/requirejs/config.js
+++ b/src/requirejs/config.js
@@ -40,5 +40,5 @@ require.config({
       deps: ["slick"]
     }
   },
-  deps: ["src/main"]
+  deps: ["main"]
 });


### PR DESCRIPTION
Use `map` config so that dynamic module IDs can be honored during
runtime when the project has been optimized to a single file.
